### PR TITLE
fix error by adjust Stream to Vector[String]

### DIFF
--- a/src/main/scala/driver/KojoMain.scala
+++ b/src/main/scala/driver/KojoMain.scala
@@ -1322,7 +1322,8 @@ object KojoMain {
     def loadLayout(layout0: String): GameState = {
       var row = 0
       var col = 0
-      val layout = layout0.lines.filter { _.length > 0 }.toVector.reverse
+      val layout: Vector[String] = // a hack to nail down the type to Vector[String] instead of Vector[AnyRef]
+        layout0.lines.filter { _.length > 0 }.toArray.toVector.reverse.map(_.asInstanceOf[String])
       val numRows = layout.length
       val numCols = layout(0).length
 
@@ -1707,7 +1708,8 @@ object KojoMain {
     def loadLayout(layout0: String): GameState = {
       var row = 0
       var col = 0
-      val layout = layout0.lines.filter { _.length > 0 }.toVector.reverse
+      val layout: Vector[String] = // a hack to nail down the type as Vector[String] instead of Vector[AnyRef]
+        layout0.lines.filter { _.length > 0 }.toArray.toVector.reverse.map(_.asInstanceOf[String])
       val numRows = layout.length
       val numCols = layout(0).length
 

--- a/src/main/scala/kojo/SwedishTurtle.scala
+++ b/src/main/scala/kojo/SwedishTurtle.scala
@@ -17,6 +17,8 @@ class SwedishTurtle(val englishTurtle: Turtle) {
 
   def hoppa(steg: Double) = englishTurtle.hop(steg)
 
+  def hoppa() = englishTurtle.hop(25)
+
   def sakta(n: Long) = englishTurtle.setAnimationDelay(n)
 
   //loops in Swedish


### PR DESCRIPTION
Proposing this temporary hack to fix this compile error:

```scala
info] Compiling 53 Scala sources to /home/bjornr/git/hub/bjornregnell/kojojs-dev/target/scala-2.12/classes...
[info]   Compilation completed in 6.142 s
[error] /home/bjornr/git/hub/bjornregnell/kojojs-dev/src/main/scala/driver/KojoMain.scala:1325: value toVector is not a member of java.util.stream.Stream[String]
[error]       val layout = layout0.lines.filter { _.length > 0 }.toVector.reverse
[error]                                                          ^
[error] /home/bjornr/git/hub/bjornregnell/kojojs-dev/src/main/scala/driver/KojoMain.scala:1710: value toVector is not a member of java.util.stream.Stream[String]
[error]       val layout = layout0.lines.filter { _.length > 0 }.toVector.reverse
[error]                                                          ^
[error] two errors found
[error] (compile:compileIncremental) Compilation failed
```